### PR TITLE
fix: remove quotes from string values

### DIFF
--- a/tests/test_parsed_values.py
+++ b/tests/test_parsed_values.py
@@ -1,0 +1,19 @@
+from yamlium import parse
+
+
+def test_no_quotes():
+    yml = """
+key1: 'string1'
+key2: "string2"
+key3: string3
+"""
+    y = parse(yml)
+    for i in [1, 2, 3]:
+        k, s = f"key{i}", f"string{i}"
+        assert y[k] == s
+        assert y.get(k) == s
+
+        # Also check using the walking functionality
+        for key, value, obj in y.walk_keys():
+            if key == k:
+                assert value == s

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -409,3 +409,12 @@ merged:
   <<: [*base, *override]
   additional: value
 """)
+
+
+def test_quoted_strings():
+    """Test YAML merge keys with multiple sources"""
+    comp("""
+key1: 'string1'
+key2: "string2"
+key3: string3
+""")

--- a/yamlium/nodes.py
+++ b/yamlium/nodes.py
@@ -528,11 +528,15 @@ class Scalar(Node):
         _type: Literal[T.MULTILINE_ARROW, T.MULTILINE_PIPE, T.SCALAR] = T.SCALAR,
         _is_indented: bool = False,
         _original_value: str = "",
+        _quote_char: str | None = None,
     ) -> None:
         super().__init__(_value, _line, _indent)
         self._type = _type
         self._is_indented = _is_indented
+        # Original value is used for the various null representations:
+        # null, ~, empty space
         self._original_value = _original_value
+        self._quote_char = _quote_char
 
     def __str__(self) -> str:
         return str(self._value)
@@ -544,8 +548,6 @@ class Scalar(Node):
             The Python value of this scalar.
         """
         if self._type == T.SCALAR:
-            if isinstance(self._value, str) and self._value[0] in {'"', "'"}:
-                return self._value[1:-1]
             return self._value
         if self._type == T.MULTILINE_PIPE:
             return self._value
@@ -558,6 +560,8 @@ class Scalar(Node):
                 val = "true" if self._value else "false"
             elif self._value is None:
                 val = self._original_value
+            elif self._quote_char:
+                val = f"{self._quote_char}{self._value}{self._quote_char}"
             else:
                 val = str(self._value)
         else:

--- a/yamlium/parser.py
+++ b/yamlium/parser.py
@@ -129,6 +129,7 @@ class Parser:
                 _value=_parse_scalar_type(val),
                 _is_indented=indented,
                 _original_value=val,
+                _quote_char=t.quote_char,
             )
         )
 


### PR DESCRIPTION
This PR will fix issue #13 

Making sure that quotes are stored as meta objects and not in the value itself.