### PR TITLE
fix: support multiline strings

### DIFF
--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -267,3 +267,169 @@ flow_map: [ a, 3, c]
             T.EOF,
         ],
     )
+
+
+def test_anchors_and_aliases():
+    """Test lexing of YAML anchors and aliases."""
+    yaml_input = """
+base: &base
+  name: base
+derived: *base
+"""
+    comp(
+        yaml_input,
+        [T.KEY, T.ANCHOR, T.INDENT, T.KEY, T.SCALAR, T.DEDENT, T.KEY, T.ALIAS, T.EOF],
+    )
+
+
+def test_merge_keys():
+    """Test lexing of YAML merge keys."""
+    yaml_input = """
+base: &base
+    name: base
+derived:
+    <<: *base
+    extra: value
+"""
+    comp(
+        yaml_input,
+        [
+            T.KEY,
+            T.ANCHOR,
+            T.INDENT,
+            T.KEY,
+            T.SCALAR,
+            T.DEDENT,
+            T.KEY,
+            T.INDENT,
+            T.KEY,
+            T.ALIAS,
+            T.KEY,
+            T.SCALAR,
+            T.EOF,
+        ],
+    )
+
+
+def test_nested_flow_style():
+    """Test lexing of nested flow style structures."""
+    yaml_input = """
+complex: { a: [1, 2], b: { x: 1, y: 2 } }
+"""
+    comp(
+        yaml_input,
+        [
+            T.KEY,
+            T.MAPPING_START,
+            T.KEY,
+            T.SEQUENCE_START,
+            T.SCALAR,
+            T.COMMA,
+            T.SCALAR,
+            T.SEQUENCE_END,
+            T.COMMA,
+            T.KEY,
+            T.MAPPING_START,
+            T.KEY,
+            T.SCALAR,
+            T.COMMA,
+            T.KEY,
+            T.SCALAR,
+            T.MAPPING_END,
+            T.MAPPING_END,
+            T.EOF,
+        ],
+    )
+
+
+def test_block_scalar_modifiers():
+    """Test lexing of block scalar modifiers."""
+    yaml_input = """
+literal: |
+    This is a literal
+    block scalar
+folded: >
+    This is a folded
+    block scalar
+"""
+    comp(yaml_input, [T.KEY, T.MULTILINE_PIPE, T.KEY, T.MULTILINE_ARROW, T.EOF])
+
+
+def test_document_separators():
+    """Test lexing of YAML document separators."""
+    yaml_input = """
+---
+key1: value1
+---
+key2: value2
+"""
+    comp(
+        yaml_input,
+        [
+            T.DOCUMENT_START,
+            T.KEY,
+            T.SCALAR,
+            T.DOCUMENT_START,
+            T.KEY,
+            T.SCALAR,
+            T.EOF,
+        ],
+    )
+
+
+def test_multiple_documents():
+    """Test lexing of multiple YAML documents."""
+    yaml_input = """
+---
+doc1: value1
+---
+doc2: value2
+"""
+    comp(
+        yaml_input,
+        [T.DOCUMENT_START, T.KEY, T.SCALAR, T.DOCUMENT_START, T.KEY, T.SCALAR, T.EOF],
+    )
+
+
+def test_complex_anchors():
+    """Test lexing of complex anchor and alias structures."""
+    yaml_input = """
+base: &base
+    name: base
+    items: &items
+        - one
+        - two
+derived:
+    <<: *base
+    items: *items
+"""
+    comp(
+        yaml_input,
+        [
+            T.KEY,
+            T.ANCHOR,
+            T.INDENT,
+            T.KEY,
+            T.SCALAR,
+            T.KEY,
+            T.ANCHOR,
+            T.INDENT,
+            T.DASH,
+            T.INDENT,
+            T.SCALAR,
+            T.DEDENT,
+            T.DASH,
+            T.INDENT,
+            T.SCALAR,
+            T.DEDENT,
+            T.DEDENT,
+            T.DEDENT,
+            T.KEY,
+            T.INDENT,
+            T.KEY,
+            T.ALIAS,
+            T.KEY,
+            T.ALIAS,
+            T.EOF,
+        ],
+    )

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -433,3 +433,63 @@ derived:
             T.EOF,
         ],
     )
+
+
+def test_newline_detection():
+    yaml_input = """
+key1: value1
+
+key2: value
+"""
+    comp(yaml_input, [T.KEY, T.SCALAR, T.EMPTY_LINE, T.KEY, T.SCALAR, T.EOF])
+
+
+# test multilines with newlines in them
+def test_multilines_with_newlines():
+    y1 = """
+key1: |
+
+  scalar
+"""
+    comp(y1, [T.KEY, T.MULTILINE_PIPE, T.EOF])
+
+    y2 = """
+key1: scalar start
+
+  scalar continue
+"""
+    comp(y2, [T.KEY, T.SCALAR, T.EOF])
+
+
+def test_various_multiline_newlines():
+    yml = """
+key1: |
+
+  line1
+
+  line2
+
+
+key2: scalar
+"""
+    comp(
+        yml,
+        [T.KEY, T.MULTILINE_PIPE, T.EMPTY_LINE, T.EMPTY_LINE, T.KEY, T.SCALAR, T.EOF],
+    )
+
+
+def test_irregular_multiline_indentation():
+    y1 = """
+key1: line1
+  line2
+    line3
+"""
+    y2 = """
+key1: |
+  line2
+    line3
+"""
+    for y in [y1, y2]:
+        with pytest.raises(ParsingError) as e:
+            Lexer(y).build_tokens()
+            assert "Irregular multiline string indentation" in str(e)

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -63,8 +63,11 @@ items:
         T.KEY,
         T.INDENT,
         T.DASH,
+        T.INDENT,
         T.SCALAR,
+        T.DEDENT,
         T.DASH,
+        T.INDENT,
         T.SCALAR,
         T.EOF,
     ]
@@ -77,13 +80,13 @@ def test_complex_structure():
     """Test lexing of a more complex YAML structure with nested sequences and mappings."""
     yaml_input = """
 users:
-    - name: alice
+  - name: alice
+    roles:
+      - admin
+      - user
+  - name:
       roles:
-        - admin
         - user
-    - name:
-        roles:
-            - user
     """
 
     lexer = Lexer(yaml_input)
@@ -98,11 +101,11 @@ users:
     # Verify we have the correct number of INDENT/DEDENT pairs
     n_indent = token_types.count(T.INDENT)
     n_dedent = token_types.count(T.DEDENT)
-    assert token_types.count(T.INDENT) == 5, (
-        f"Expected 5 INDENT tokens found {n_indent}"
+    assert token_types.count(T.INDENT) == 9, (
+        f"Expected 9 INDENT tokens found {n_indent}"
     )
-    assert token_types.count(T.DEDENT) == 2, (
-        f"Expected 2 DEDENT tokens found {n_dedent}"
+    assert token_types.count(T.DEDENT) == 4, (
+        f"Expected 4 DEDENT tokens found {n_dedent}"
     )
     assert token_types.count(T.KEY) == 5
 
@@ -215,6 +218,15 @@ key: simple multiline
     tokens = Lexer(yaml_input).build_tokens()
     expected_types = [T.KEY, T.SCALAR, T.EOF]
     assert [t.t for t in tokens] == expected_types
+
+
+def test_multiline_string_error():
+    yaml_input = """
+key: simple multiline
+  string illegal key:
+"""
+    with pytest.raises(ParsingError):
+        Lexer(yaml_input).build_tokens()
 
 
 def test_flow_style_mapping():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -108,7 +108,7 @@ what: *my_anchor #   Applied with simple alias
 
 
 def test_anchor_missing_key():
-    with pytest.raises(ParsingError) as e:
+    with pytest.raises(expected_exception=ParsingError) as e:
         comp("""
 hey: asdf &faulty_anchor
 """)
@@ -116,7 +116,7 @@ hey: asdf &faulty_anchor
 
 
 def test_alias_missing_anchor():
-    with pytest.raises(ParsingError) as e:
+    with pytest.raises(expected_exception=ParsingError) as e:
         comp(
             """
 hey: *missing_anchor

--- a/uv.lock
+++ b/uv.lock
@@ -810,7 +810,7 @@ wheels = [
 
 [[package]]
 name = "yamlium"
-version = "0.1.2"
+version = "0.1.4"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/yamlium/exceptions.py
+++ b/yamlium/exceptions.py
@@ -12,7 +12,7 @@ def raise_parsing_error(input_str: str, pos: int, msg: str) -> NoReturn:
     # Figure out where the error is based on pos
     for i, line in enumerate(input_split):
         line_pos_sum += len(line) + 1  # Add one since newlines are gone from split
-        if line_pos_sum >= pos:
+        if line_pos_sum >= pos + 1:  # Add one for a final newline split
             faulty_line_index = i
             break
     line_pos = pos + len(line) - line_pos_sum

--- a/yamlium/nodes.py
+++ b/yamlium/nodes.py
@@ -565,18 +565,19 @@ class Scalar(Node):
             else:
                 val = str(self._value)
         else:
-            prefix = "|" if self._type == T.MULTILINE_PIPE else ">"
-            i_ = _indent(i)
-            val = (
-                prefix
-                + "\n"
-                + "\n".join(
-                    [
-                        (i_ + r) if r else ""
-                        for r in self._value.split("\n")  # type: ignore
-                    ]
+            val = "|" if self._type == T.MULTILINE_PIPE else ">"
+            if self._value:
+                i_ = _indent(i)
+                val = (
+                    val
+                    + "\n"
+                    + "\n".join(
+                        [
+                            (i_ + r) if r else ""
+                            for r in self._value.split("\n")  # type: ignore
+                        ]
+                    )
                 )
-            )
         return self._enrich_yaml(val)
 
     if TYPE_CHECKING:

--- a/yamlium/parser.py
+++ b/yamlium/parser.py
@@ -319,7 +319,7 @@ class Parser:
         # Set up class vars
         self.pos = 0
         self.current_indent = 0
-        self.tokens = Lexer(input=self.input).build_tokens()
+        self.tokens = Lexer(self.input).build_tokens()
         self.num_tokens = len(self.tokens)
         self.node_stack: deque[Node] = deque([])
         self.anchors: dict[str, Node] = {}


### PR DESCRIPTION
This will fix issue #11 

Support for:
```yaml
key: scalar start
  scalar continue
```

Additionally fundamental changes to `Lexer()` to a semi-recursive approach to easier enable advanced tokenization.