### PR TITLE
fix: allow negative scalars in sequence

### DIFF
--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -493,3 +493,36 @@ key1: |
         with pytest.raises(ParsingError) as e:
             Lexer(y).build_tokens()
             assert "Irregular multiline string indentation" in str(e)
+
+
+def test_dashes_in_sequence():
+    yml = """
+key1:
+  - normal
+  - 123
+  - -123 # negative number
+  - -"""  # The final is a dash with immediate EOF
+    comp(
+        yml,
+        [
+            T.KEY,
+            T.INDENT,
+            T.DASH,
+            T.INDENT,
+            T.SCALAR,
+            T.DEDENT,
+            T.DASH,
+            T.INDENT,
+            T.SCALAR,
+            T.DEDENT,
+            T.DASH,
+            T.INDENT,
+            T.SCALAR,
+            T.COMMENT,
+            T.DEDENT,
+            T.DASH,
+            T.INDENT,
+            T.SCALAR,
+            T.EOF,
+        ],
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -810,7 +810,7 @@ wheels = [
 
 [[package]]
 name = "yamlium"
-version = "0.1.4"
+version = "0.1.6"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/yamlium/lexer.py
+++ b/yamlium/lexer.py
@@ -97,6 +97,13 @@ class Lexer:
         """Get current character."""
         return self.input[self.position]
 
+    @property
+    def c_future(self) -> str | None:
+        """Get character one position in the future."""
+        if self.position + 1 >= self.input_length:
+            return None
+        return self.input[self.position + 1]
+
     def _parse_next_token(self, extra_stop_chars: set = set()) -> Token:
         """Get the next token from the input."""
         # Check if we're at the end of document.
@@ -348,7 +355,9 @@ class Lexer:
         )
 
     def _parse_dash(self) -> Token:
-        # Start with char, since current char is '-'
+        # If the token after is not a dash or blankspace then we're dealing with a scalar
+        if not self.c_future or self.c_future not in {" ", "-"}:
+            return self._parse_scalar()
         self._nc()
         s = self._snapshot
         # Check if next character is also a dash, i.e. document separator


### PR DESCRIPTION
Support for negative scalars in sequence:

```yml
key:
  - item1
  - 13 # positive number, this worked before
  - -13 # negative number, this did not work before
```