### PR TITLE
fix: indented scalar

### DIFF
--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -534,3 +534,67 @@ normal_key:
   "quoted_key": scalar
 """
     comp(yml, [T.KEY, T.INDENT, T.KEY, T.SCALAR, T.EOF])
+
+
+def test_flow_seq_in_seq():
+    y = """
+flow_seq: [1, [3, 4], 5]
+"""
+    comp(
+        y,
+        [
+            T.KEY,
+            T.SEQUENCE_START,
+            T.SCALAR,
+            T.COMMA,
+            T.SEQUENCE_START,
+            T.SCALAR,
+            T.COMMA,
+            T.SCALAR,
+            T.SEQUENCE_END,
+            T.COMMA,
+            T.SCALAR,
+            T.SEQUENCE_END,
+            T.EOF,
+        ],
+    )
+
+
+def test_mixed_flow_style():
+    yml = """
+mixed: { a: [1, 2], b: { x: 1, y: 2 }, c: [3, { z: 4 }] }
+"""
+    comp(
+        yml,
+        [
+            T.KEY,
+            T.MAPPING_START,
+            T.KEY,
+            T.SEQUENCE_START,
+            T.SCALAR,
+            T.COMMA,
+            T.SCALAR,
+            T.SEQUENCE_END,
+            T.COMMA,
+            T.KEY,
+            T.MAPPING_START,
+            T.KEY,
+            T.SCALAR,
+            T.COMMA,
+            T.KEY,
+            T.SCALAR,
+            T.MAPPING_END,
+            T.COMMA,
+            T.KEY,
+            T.SEQUENCE_START,
+            T.SCALAR,
+            T.COMMA,
+            T.MAPPING_START,
+            T.KEY,
+            T.SCALAR,
+            T.MAPPING_END,
+            T.SEQUENCE_END,
+            T.MAPPING_END,
+            T.EOF,
+        ],
+    )

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -478,23 +478,6 @@ key2: scalar
     )
 
 
-def test_irregular_multiline_indentation():
-    y1 = """
-key1: line1
-  line2
-    line3
-"""
-    y2 = """
-key1: |
-  line2
-    line3
-"""
-    for y in [y1, y2]:
-        with pytest.raises(ParsingError) as e:
-            Lexer(y).build_tokens()
-            assert "Irregular multiline string indentation" in str(e)
-
-
 def test_dashes_in_sequence():
     yml = """
 key1:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -418,3 +418,24 @@ key1: 'string1'
 key2: "string2"
 key3: string3
 """)
+
+
+def test_irregular_multiline_indentation():
+    comp("""
+key1: line1
+  line2
+    line3
+
+key2: |
+  line2
+  line3
+""")
+
+
+def test_scalar_starting_after_key():
+    comp("""
+key1:
+  scalar start
+
+  scalar_continue
+""")

--- a/tests/test_root_functions.py
+++ b/tests/test_root_functions.py
@@ -118,12 +118,6 @@ def test_from_dict_list():
     assert isinstance(result[3], Mapping)
 
 
-def test_invalid_yaml():
-    """Test parsing invalid YAML."""
-    with pytest.raises(ParsingError):
-        parse("invalid: yaml: : :")
-
-
 def test_invalid_json():
     """Test parsing invalid JSON."""
     with pytest.raises(json.JSONDecodeError):

--- a/yamlium/parser.py
+++ b/yamlium/parser.py
@@ -120,8 +120,8 @@ class Parser:
     # ------------------------------------------------------------------
     def _build_scalar(self, in_mapping: bool = False) -> Scalar:
         t = self._take_token
-        val = t.value.strip()
-        indented = in_mapping and t.line > self._current_line
+        val = t.value.rstrip()
+        indented = in_mapping and t.line > self._current_line and t.t == T.SCALAR
         return self._process_node(
             Scalar(
                 _type=t.t,  # type: ignore


### PR DESCRIPTION
This PR will allow:
```yml
# Scalars that start on a new line
key:
  scalar
  with multiline

# Scalars containing <
key: my <href>...

# Scalars containing :
key: not:a:key
```