### PR TITLE
fix: indentation of multiline in sequence

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -439,3 +439,26 @@ key1:
 
   scalar_continue
 """)
+
+
+def test_deeply_nested_multiline():
+    comp("""
+key1:
+  key2:
+    key3: |
+      some text
+      on multiple lines
+    key4: normal scalar
+""")
+
+
+def test_multiline_in_sequence():
+    comp("""
+key1:
+  - name: item1
+    meta: |
+      some multiline
+      text
+  - name: item2
+    meta: some single line info
+""")

--- a/yamlium/nodes.py
+++ b/yamlium/nodes.py
@@ -408,7 +408,7 @@ class Sequence(list, Node):
                         # If it is another block, add newline
                         items.append(f"{prefix2}{k._to_yaml()}\n{v._to_yaml(i + 2)}")
                     else:
-                        items.append(f"{prefix2}{k._to_yaml()} {v._to_yaml(i + 1)}")
+                        items.append(f"{prefix2}{k._to_yaml()} {v._to_yaml(i + 2)}")
                     prefix2 = prefix2[:-2] + "  "  # Clean up prefix if deeper mapping.
 
             else:


### PR DESCRIPTION
This will fix indentation when keeping multiline scalars in sequence e.g.

```yml
key1:
  - name: alice
    desc: |
      asdf
```