### PR TITLE
fix: comments in sequences

### DIFF
--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -23,57 +23,45 @@ def test_simple_key_value():
 
 def test_nested_mapping():
     """Test lexing of nested mappings with indentation."""
-    yaml_input = """
+    comp(
+        """
 person:
     name: alice
     age: 30
-    """
-
-    lexer = Lexer(yaml_input)
-    tokens = lexer.build_tokens()
-
-    # Expected token sequence: NEW_LINE, KEY, NEW_LINE, INDENT, KEY, STRING, NEW_LINE, KEY, STRING, DEDENT, EOF
-    expected_types = [
-        T.KEY,
-        T.INDENT,
-        T.KEY,
-        T.SCALAR,
-        T.KEY,
-        T.SCALAR,
-        T.EOF,
-    ]
-
-    assert len(tokens) == len(expected_types)
-    assert [t.t for t in tokens] == expected_types
+""",
+        [
+            T.KEY,
+            T.INDENT,
+            T.KEY,
+            T.SCALAR,
+            T.KEY,
+            T.SCALAR,
+            T.EOF,
+        ],
+    )
 
 
 def test_sequence():
     """Test lexing of sequences (lists)."""
-    yaml_input = """
+    comp(
+        """
 items:
     - first
     - second
-    """
-
-    lexer = Lexer(yaml_input)
-    tokens = lexer.build_tokens()
-
-    # Expected: NEW_LINE, KEY, NEW_LINE, INDENT, DASH, STRING, NEW_LINE, DASH, STRING, DEDENT, EOF
-    expected_types = [
-        T.KEY,
-        T.INDENT,
-        T.DASH,
-        T.INDENT,
-        T.SCALAR,
-        T.DEDENT,
-        T.DASH,
-        T.INDENT,
-        T.SCALAR,
-        T.EOF,
-    ]
-
-    assert len(tokens) == len(expected_types)
-    assert [t.t for t in tokens] == expected_types
+    """,
+        [
+            T.KEY,
+            T.INDENT,
+            T.DASH,
+            T.INDENT,
+            T.SCALAR,
+            T.DEDENT,
+            T.DASH,
+            T.INDENT,
+            T.SCALAR,
+            T.EOF,
+        ],
+    )
 
 
 def test_complex_structure():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -462,3 +462,13 @@ key1:
   - name: item2
     meta: some single line info
 """)
+
+
+def test_comments_in_sequences():
+    comp("""
+key1:
+  # Comment on sequence item start
+  - key: val
+    # Comment on mapping object
+    key2: val
+""")

--- a/yamlium/lexer.py
+++ b/yamlium/lexer.py
@@ -470,6 +470,10 @@ class Lexer:
 
         # Otherwise parse blank spaces until we find something else
         indent = self._count_spaces()
+        # If it is a comment line, ignore any empty space
+        if self.c_future == "#":
+            return self._parse_comment()
+
         return self._maybe_add_dents(indent=indent)
 
     def _nc(self) -> None:

--- a/yamlium/nodes.py
+++ b/yamlium/nodes.py
@@ -393,25 +393,30 @@ class Sequence(list, Node):
             vals = ", ".join([v._to_yaml() for v in self])
             return self._enrich_yaml("[" + vals + "]")
         items = []
-        prefix = _indent(i) + "- "
         for x in self:
             # Check if we should print standalone comments
             items.extend(x._get_sa_comments(i=i))
 
             # If child is a mapping
             if isinstance(x, Mapping):
-                prefix2 = prefix
+                is_first_item = True
                 for k, v in x.items():
-                    items.extend(k._get_sa_comments(i=i))
+                    if is_first_item:
+                        prefix = _indent(i) + "- "
+                        items.extend(k._get_sa_comments(i=i))
+                    else:
+                        prefix = _indent(i) + "  "
+                        items.extend(k._get_sa_comments(i=i + 1))
 
                     if isinstance(v, (Mapping, Sequence)):
                         # If it is another block, add newline
-                        items.append(f"{prefix2}{k._to_yaml()}\n{v._to_yaml(i + 2)}")
+                        items.append(f"{prefix}{k._to_yaml()}\n{v._to_yaml(i + 2)}")
                     else:
-                        items.append(f"{prefix2}{k._to_yaml()} {v._to_yaml(i + 2)}")
-                    prefix2 = prefix2[:-2] + "  "  # Clean up prefix if deeper mapping.
+                        items.append(f"{prefix}{k._to_yaml()} {v._to_yaml(i + 2)}")
+                    is_first_item = False
 
             else:
+                prefix = _indent(i) + "- "
                 items.append(f"{prefix}{x._to_yaml(i + 1)}")
         return "\n".join(items)
 


### PR DESCRIPTION
This will fix any comments in sequences e.g.

```yml
key1:
  # Comment on sequence item start
  - key: val
    # Comment on mapping object
    key2: val
```