### PR TITLE
fix: quoted strings remain strings

### DIFF
--- a/tests/test_parsed_values.py
+++ b/tests/test_parsed_values.py
@@ -17,3 +17,13 @@ key3: string3
         for key, value, obj in y.walk_keys():
             if key == k:
                 assert value == s
+
+
+def test_quoted_values():
+    # Without quotes
+    assert parse("key: false")["key"] == False  # noqa: E712
+    assert parse("key: 123")["key"] == 123
+    # With quotes
+    assert parse('key: "false"')["key"] == "false"
+    assert parse("key: 'false'")["key"] == "false"
+    assert parse("key: '123'")["key"] == "123"

--- a/yamlium/lexer.py
+++ b/yamlium/lexer.py
@@ -97,9 +97,9 @@ class Lexer:
         print(" " * (self.column - 1), "^" + f"-({self.c}, column={self.column})")
 
     @property
-    def c(self) -> str:
+    def c(self) -> str | None:
         """Get current character."""
-        return self.input[self.position]
+        return self.input[self.position] if self.position < self.input_length else None
 
     @property
     def c_future(self) -> str | None:

--- a/yamlium/parser.py
+++ b/yamlium/parser.py
@@ -126,7 +126,7 @@ class Parser:
             Scalar(
                 _type=t.t,  # type: ignore
                 _line=t.line,
-                _value=_parse_scalar_type(val),
+                _value=_parse_scalar_type(val) if not t.quote_char else str(val),
                 _is_indented=indented,
                 _original_value=val,
                 _quote_char=t.quote_char,


### PR DESCRIPTION
This will fix recently introduced bug keeping quoted strings as strings.