### PR TITLE
fix: allow irregular multiline

### DIFF
--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -569,3 +569,16 @@ mixed: { a: [1, 2], b: { x: 1, y: 2 }, c: [3, { z: 4 }] }
             T.EOF,
         ],
     )
+
+
+def test_irregular_multiline_indentation():
+    yml = """
+key: >
+  start:
+    - a bullet list
+    - bullet 2
+  some more text
+    - new bullets
+key2: normal scalar
+"""
+    comp(yml, [T.KEY, T.MULTILINE_ARROW, T.KEY, T.SCALAR, T.EOF])

--- a/yamlium/lexer.py
+++ b/yamlium/lexer.py
@@ -288,8 +288,6 @@ class Lexer:
                     multiline_indentation_level = indent
                 # Otherwise compare against the multiline indentation level
                 else:
-                    if indent > multiline_indentation_level:
-                        self._raise_error(msg="Irregular multiline string indentation.")
                     if indent < multiline_indentation_level:
                         break
             else:


### PR DESCRIPTION
Allow irregular multiline such as:

```yml
key: >
  start:
    - a bullet list
    - bullet 2
  some more text
    - new bullets
key2: normal scalar
```