### PR TITLE
fix: newlines in quotes

### DIFF
--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -582,3 +582,21 @@ key: >
 key2: normal scalar
 """
     comp(yml, [T.KEY, T.MULTILINE_ARROW, T.KEY, T.SCALAR, T.EOF])
+
+
+def test_single_quoted_multiline_string():
+    """Test that single-quoted strings can span multiple lines."""
+    yaml_input = """
+key: 'foo
+  bar'
+"""
+    comp(yaml_input, [T.KEY, T.SCALAR, T.EOF])
+
+
+def test_double_quoted_multiline_string():
+    """Test that double-quoted strings can span multiple lines."""
+    yaml_input = """
+key: "foo
+  bar"
+"""
+    comp(yaml_input, [T.KEY, T.SCALAR, T.EOF])

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -477,3 +477,19 @@ key1:
 def test_empty_yaml():
     assert parse("").to_yaml() == ""
     assert parse_full("").to_yaml() == ""
+
+
+def test_single_quoted_multiline():
+    """Test that single-quoted strings can span multiple lines and preserve formatting."""
+    comp("""
+key: 'foo
+  bar'
+""")
+
+
+def test_double_quoted_multiline():
+    """Test that double-quoted strings can span multiple lines and preserve formatting."""
+    comp("""
+key: "foo
+  bar"
+""")

--- a/yamlium/lexer.py
+++ b/yamlium/lexer.py
@@ -345,14 +345,15 @@ class Lexer:
         self._nc()
         char = self.c
         while char != quote_char:
-            self._nc()
+            if char == "\n":
+                # In YAML, quoted strings can span multiple lines
+                # Track the newline for proper line/column tracking
+                self._nl()
+            else:
+                self._nc()
             if self.position >= self.input_length:
                 self._raise_error(msg="Expected end of quote.", pos=start.position)
             char = self.c
-            if char == "\n":
-                self._raise_error(
-                    msg="Quoted string broken by newline.", pos=start.position
-                )
         self._nc()  # Consume the final quote
         # It might be a quoted key
         if self.c == ":":


### PR DESCRIPTION
Support for handling newlines within quoted Scalars such as below. Closes #35 

```py
import yamlium

yaml = '''
key: 'foo
  bar'
'''
yamlium.parse(yaml)
```