### PR TITLE
fix: indentations in multiline scalar

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -464,6 +464,63 @@ key1:
 """)
 
 
+def test_multiline_folded_with_indentation():
+    """Test folded scalar (>) with indented content."""
+    comp("""
+key: >
+  - text for scalar
+    - indented bullet
+  - more text
+""")
+
+
+def test_multiline_literal_with_indentation():
+    """Test literal scalar (|) with indented content."""
+    comp("""
+key: |
+  line 1
+    indented line
+  line 3
+""")
+
+
+def test_multiline_with_multiple_indentation_levels():
+    """Test multiline scalar with multiple levels of indentation."""
+    comp("""
+key: >
+  text
+    level 1
+      level 2
+    back to 1
+  back to base
+""")
+
+
+def test_multiline_literal_with_empty_lines_and_indentation():
+    """Test literal scalar with empty lines and indentation."""
+    comp("""
+key: |
+  line 1
+
+    indented line
+
+  back to base
+""")
+
+
+def test_multiline_folded_code_block():
+    """Test folded scalar with code-like indented content."""
+    comp("""
+description: >
+  This function does:
+    - step 1
+    - step 2
+      - nested step
+    - step 3
+  End of description
+""")
+
+
 def test_comments_in_sequences():
     comp("""
 key1:

--- a/uv.lock
+++ b/uv.lock
@@ -810,7 +810,7 @@ wheels = [
 
 [[package]]
 name = "yamlium"
-version = "0.1.6"
+version = "0.1.14"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/yamlium/lexer.py
+++ b/yamlium/lexer.py
@@ -296,7 +296,27 @@ class Lexer:
 
         value = self.input[s.position : self.position]
         split = value.strip().split("\n")
-        value = "\n".join([x.strip() for x in split[1:]])
+
+        # Find the base indentation level (indentation of first non-empty line)
+        # We need to preserve relative indentation within the multiline scalar
+        base_indent = multiline_indentation_level if multiline_indentation_level else 0
+
+        # Process each line: remove base indentation but preserve additional indentation
+        processed_lines = []
+        for line in split[1:]:  # Skip the first line (which is just "|" or ">")
+            if not line.strip():  # Empty line
+                processed_lines.append("")
+            else:
+                # Count leading spaces on this line
+                line_indent = len(line) - len(line.lstrip())
+                # Remove base indentation, keep any additional indentation
+                if line_indent >= base_indent:
+                    processed_lines.append(line[base_indent:])
+                else:
+                    # Line has less indentation than base - just strip it
+                    processed_lines.append(line.strip())
+
+        value = "\n".join(processed_lines)
 
         tokens = self._build_token(t=multiline_type, value=value, s=s)
 


### PR DESCRIPTION
Implement support for indentation retention in multiline scalars (example below), closes #36 .

```yml
key: >
  - text for scalar
    - indented bullet
  - more text
```