### PR TITLE
Fix empty collections, inline parsing, and multiline strings

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -190,6 +190,31 @@ nested_empty:
 """)
 
 
+def test_inline_sequence_no_trailing_newline():
+    result = parse("q: []")
+    assert result.to_yaml() == "q: []\n"
+
+
+def test_inline_mapping_no_trailing_newline():
+    result = parse("q: {}")
+    assert result.to_yaml() == "q: {}\n"
+
+
+def test_inline_sequence_with_values_no_trailing_newline():
+    result = parse("q: [1, 2, 3]")
+    assert result.to_yaml() == "q: [1, 2, 3]\n"
+
+
+def test_inline_no_newline_matches_with_newline():
+    r1 = parse("q: []")
+    r2 = parse("q: []\n")
+    assert r1.to_yaml() == r2.to_yaml()
+
+
+def test_parsed_empty_inline_roundtrip():
+    comp("q: []\n")
+
+
 def test_complex_nesting():
     """Test deeply nested structures"""
     comp("""

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -215,6 +215,16 @@ def test_parsed_empty_inline_roundtrip():
     comp("q: []\n")
 
 
+def test_standalone_flow_sequence():
+    result = parse_full("[1, 2, 3]\n")
+    assert len(result) == 1
+
+
+def test_standalone_flow_mapping():
+    result = parse_full("{a: 1, b: 2}\n")
+    assert len(result) == 1
+
+
 def test_complex_nesting():
     """Test deeply nested structures"""
     comp("""

--- a/tests/test_root_functions.py
+++ b/tests/test_root_functions.py
@@ -118,6 +118,47 @@ def test_from_dict_list():
     assert isinstance(result[3], Mapping)
 
 
+def test_from_dict_empty_list():
+    result = from_dict({"q": []})
+    assert result.to_yaml() == "q: []\n"
+
+
+def test_from_dict_empty_dict():
+    result = from_dict({"q": {}})
+    assert result.to_yaml() == "q: {}\n"
+
+
+def test_from_dict_empty_list_and_dict():
+    result = from_dict({"q": [], "w": {}})
+    assert result.to_yaml() == "q: []\nw: {}\n"
+
+
+def test_from_dict_nested_empty():
+    result = from_dict({"a": {"b": []}})
+    assert result.to_yaml() == "a:\n  b: []\n"
+
+
+def test_from_dict_setitem_empty_list():
+    m = from_dict({"key": "value"})
+    m["key"] = []
+    assert "key: []\n" in m.to_yaml()
+
+
+def test_from_dict_empty_nested_in_non_empty():
+    result = from_dict({"a": [1, [], 3]})
+    assert "[]" in result.to_yaml()
+
+
+def test_from_dict_non_empty_list_stays_block():
+    result = from_dict({"q": [1, 2]})
+    assert result.to_yaml() == "q:\n  - 1\n  - 2\n"
+
+
+def test_from_dict_non_empty_dict_stays_block():
+    result = from_dict({"q": {"a": 1}})
+    assert "{" not in result.to_yaml()
+
+
 def test_invalid_json():
     """Test parsing invalid JSON."""
     with pytest.raises(json.JSONDecodeError):

--- a/tests/test_root_functions.py
+++ b/tests/test_root_functions.py
@@ -118,6 +118,16 @@ def test_from_dict_list():
     assert isinstance(result[3], Mapping)
 
 
+def test_from_dict_bare_empty_dict():
+    result = from_dict({})
+    assert result.to_yaml() == "{}\n"
+
+
+def test_from_dict_bare_empty_list():
+    result = from_dict([])
+    assert result.to_yaml() == "[]\n"
+
+
 def test_from_dict_empty_list():
     result = from_dict({"q": []})
     assert result.to_yaml() == "q: []\n"

--- a/tests/test_root_functions.py
+++ b/tests/test_root_functions.py
@@ -159,6 +159,41 @@ def test_from_dict_non_empty_dict_stays_block():
     assert "{" not in result.to_yaml()
 
 
+def test_from_dict_multiline_string():
+    result = from_dict({"a": "b\nc"})
+    assert result.to_yaml() == "a: |-\n  b\n  c\n"
+
+
+def test_from_json_multiline_string():
+    result = from_json('{"a": "b\\nc"}')
+    assert result.to_yaml() == "a: |-\n  b\n  c\n"
+
+
+def test_from_dict_multiline_with_trailing_newline():
+    result = from_dict({"a": "b\nc\n"})
+    assert result.to_yaml() == "a: |\n  b\n  c\n"
+
+
+def test_from_dict_plain_string_stays_scalar():
+    result = from_dict({"a": "hello"})
+    assert result.to_yaml() == "a: hello\n"
+
+
+def test_from_dict_empty_string_stays_scalar():
+    result = from_dict({"a": ""})
+    assert "|" not in result.to_yaml()
+
+
+def test_from_dict_int_unaffected():
+    result = from_dict({"a": 42})
+    assert result.to_yaml() == "a: 42\n"
+
+
+def test_from_dict_bool_unaffected():
+    result = from_dict({"a": True})
+    assert result.to_yaml() == "a: true\n"
+
+
 def test_invalid_json():
     """Test parsing invalid JSON."""
     with pytest.raises(json.JSONDecodeError):

--- a/yamlium/__init__.py
+++ b/yamlium/__init__.py
@@ -76,7 +76,10 @@ def from_json(input: str | Path) -> Mapping | Sequence:
         input = input.read_text()
     elif input.endswith(".json"):
         input = Path(input).read_text()
-    return _convert_type(json.loads(input))  # type: ignore
+    result = _convert_type(json.loads(input))
+    # Mark as root-level so to_yaml() appends a trailing newline
+    result._indent = 0
+    return result  # type: ignore
 
 
 def from_dict(input: dict | list) -> Mapping | Sequence:
@@ -91,7 +94,10 @@ def from_dict(input: dict | list) -> Mapping | Sequence:
     Returns:
         Union[Mapping, Sequence]: A Mapping object for dictionaries, or a Sequence object for lists.
     """
-    return _convert_type(input)  # type: ignore
+    result = _convert_type(input)
+    # Mark as root-level so to_yaml() appends a trailing newline
+    result._indent = 0
+    return result  # type: ignore
 
 
 __all__ = [

--- a/yamlium/lexer.py
+++ b/yamlium/lexer.py
@@ -189,7 +189,7 @@ class Lexer:
                     inner -= 1
                     if inner < 0:
                         stop = True
-                if t.t == T.EOF or self.position >= self.input_length:
+                if not stop and (t.t == T.EOF or self.position >= self.input_length):
                     flow_type = "mapping" if mapping else "sequence"
                     self._raise_error(f"Inline {flow_type} not closed.", pos=s.position)
         return tokens
@@ -312,7 +312,9 @@ class Lexer:
 
         # Process each line: remove base indentation but preserve additional indentation
         processed_lines = []
-        for line in split[1:]:  # Skip the first line (which is just "|", ">", "|-", etc.)
+        for line in split[
+            1:
+        ]:  # Skip the first line (which is just "|", ">", "|-", etc.)
             if not line.strip():  # Empty line
                 processed_lines.append("")
             else:

--- a/yamlium/nodes.py
+++ b/yamlium/nodes.py
@@ -37,11 +37,11 @@ def _convert_type(obj: Any, /) -> Node:
     if hasattr(obj, "_managed"):
         return obj  # type: ignore
     if isinstance(obj, dict):
-        return Mapping(
-            {Key(_value=key): _convert_type(value) for key, value in obj.items()}
-        )
+        items = {Key(_value=key): _convert_type(value) for key, value in obj.items()}
+        return Mapping(items, _is_inline=not items)
     if isinstance(obj, list):
-        return Sequence([_convert_type(item) for item in obj])
+        items = [_convert_type(item) for item in obj]
+        return Sequence(items, _is_inline=not items)
     return Scalar(_value=obj)
 
 
@@ -232,7 +232,9 @@ class Node:
     def _get_foot_comments(self, i: int) -> list[str]:
         return [_indent(i) + c for c in self.comments.foot]
 
-    def _enrich_yaml(self, s: str, /, i: int = 0, foot_indent: int | None = None) -> str:
+    def _enrich_yaml(
+        self, s: str, /, i: int = 0, foot_indent: int | None = None
+    ) -> str:
         output = s
         if self.comments.line:
             output += f" {self.comments.line}"
@@ -491,7 +493,9 @@ class Sequence(list, Node):
                         # If it is another block, add newline
                         items.append(f"{prefix}{k._to_yaml()}\n{v._to_yaml(i + 2)}")
                     elif isinstance(v, Scalar):
-                        items.append(f"{prefix}{k._to_yaml()} {v._to_yaml(i + 2, foot_indent=i + 1)}")
+                        items.append(
+                            f"{prefix}{k._to_yaml()} {v._to_yaml(i + 2, foot_indent=i + 1)}"
+                        )
                     else:
                         items.append(f"{prefix}{k._to_yaml()} {v._to_yaml(i + 2)}")
                     is_first_item = False
@@ -684,7 +688,9 @@ class Scalar(Node):
                 i_ = _indent(i)
                 # For the value, we need to strip trailing newlines for proper formatting
                 # (chomping is already applied in the lexer and stored in _value)
-                content = self._value.rstrip("\n") if isinstance(self._value, str) else ""
+                content = (
+                    self._value.rstrip("\n") if isinstance(self._value, str) else ""
+                )
                 val = (
                     val
                     + "\n"

--- a/yamlium/nodes.py
+++ b/yamlium/nodes.py
@@ -42,6 +42,9 @@ def _convert_type(obj: Any, /) -> Node:
     if isinstance(obj, list):
         items = [_convert_type(item) for item in obj]
         return Sequence(items, _is_inline=not items)
+    if isinstance(obj, str) and "\n" in obj:
+        chomp = "" if obj.endswith("\n") else "-"
+        return Scalar(_value=obj, _type=T.MULTILINE_PIPE, _chomp=chomp)
     return Scalar(_value=obj)
 
 

--- a/yamlium/nodes.py
+++ b/yamlium/nodes.py
@@ -278,7 +278,11 @@ class Node:
         Returns:
             A string containing the YAML representation of this node.
         """
-        return self._to_yaml()
+        result = self._to_yaml()
+        # Ensure trailing newline for root-level inline collections
+        if self._indent == 0 and not result.endswith("\n"):
+            result += "\n"
+        return result
 
     def yaml_dump(self, destination: str | Path) -> None:
         """Write the node's YAML representation to a file.

--- a/yamlium/parser.py
+++ b/yamlium/parser.py
@@ -452,9 +452,9 @@ class Parser:
             elif self._check_special_types(t=t):
                 continue
             elif t == T.MAPPING_START:
-                self._parse_inline_mapping()
+                root.append(self._parse_inline_mapping())
             elif t == T.SEQUENCE_START:
-                self._parse_inline_sequence()
+                root.append(self._parse_inline_sequence())
             elif t == T.DOCUMENT_START:
                 self._take_token
             elif t == T.EOF:


### PR DESCRIPTION
## Summary

- Empty collections from `from_dict`/`from_json` now render as inline `[]`/`{}` instead of producing broken YAML
- Inline sequences/mappings no longer require a trailing newline to parse
- Multiline strings from `from_dict`/`from_json` are converted to pipe-style scalars instead of producing invalid YAML
- Standalone flow-style documents are no longer silently discarded by the parser

Closes #54 and #55