### PR TITLE
Parsing indented inline maps and quoted keys

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -176,6 +176,22 @@ def test_flow_style():
 flow_map: { a: 1, b: 2, c: 3 }
 flow_seq: [1, 2, 3, 4]
 mixed: { a: [1, 2], b: { x: 1, y: 2 } }
+pretty: {
+  "a": [
+    1,
+    2,
+  ],
+  "b": {
+    "x": 1,
+    y: 2
+  }
+}
+""",
+         expected_result="""
+flow_map: { a: 1, b: 2, c: 3 }
+flow_seq: [1, 2, 3, 4]
+mixed: { a: [1, 2], b: { x: 1, y: 2 } }
+pretty: { "a": [1, 2], "b": { "x": 1, y: 2 } }
 """)
 
 

--- a/tests/test_parser_to_json.py
+++ b/tests/test_parser_to_json.py
@@ -338,3 +338,22 @@ final:
             },
         },
     )
+
+
+def test_quoted_keys():
+    """Test quoted keys"""
+    _comp(
+        """
+'key': 'value'
+"key2": "value2"
+flow: { "key": "value", '"key2"': value2 }
+""",
+        {
+            "key": "value",
+            "key2": "value2",
+            "flow": {
+                "key": "value",
+                "\"key2\"": "value2"
+            }
+        }
+    )

--- a/yamlium/lexer.py
+++ b/yamlium/lexer.py
@@ -182,6 +182,8 @@ class Lexer:
         inner = 0  # Sometimes we have flow within flow like: [a, [b, c]]
         while not stop:
             for t in self._parse_next_token(extra_stop_chars=extra_scalar_stops):
+                if t.t in {T.INDENT, T.DEDENT}:
+                    continue
                 tokens.append(t)
                 if t.t == start_token_type:
                     inner += 1

--- a/yamlium/nodes.py
+++ b/yamlium/nodes.py
@@ -60,6 +60,12 @@ def _preserve_metadata(old_value: Node | None, new_value: Node) -> Node:
     return new_value
 
 
+def _strip_quotes(value):
+    if len(value) >= 2 and value[0] in ('"', "'") and value[0] == value[-1]:
+        return value[1:-1]
+    return value
+
+
 class StrManipulator:
     """This class allows string manipulation."""
 
@@ -312,7 +318,8 @@ class Node:
                     else:
                         val.update(v.to_dict())  # type: ignore
                 else:
-                    val[k._value] = v.to_dict()
+                    key = _strip_quotes(k._value)
+                    val[key] = v.to_dict()
             return val
         if isinstance(self, Alias):
             return self.child.to_dict()


### PR DESCRIPTION
I've attempted to fix two issues here.

First, parsing of inline maps simply crashed when running into a T.INDENT token. Since the lexer already knows that it is inside an inline map, the solution is to simply not emit INDENT or DEDENT tokens. The parser doesn't even need to see them. I'm actually not sure if DEDENT tokens could ever be generated here, but if they are I think they would also crash the parser, so it seems reasonable to filter them out too.

The other issue is with quoted keys. It seems they have no special handling, the quotes are kept as part of the key:
```
yamlium.parse('"a": b')
Key('"a"'): Scalar('b')
```
This is not necessarily a bad thing, because it allows to_yaml() to recreate the yaml file with the same quoting, but it causes to_dict() to create incorrect keys:
```
yamlium.parse('"a": b').to_dict()
{'"a"': 'b'}
```
The string value of the key should be `a`, not `"a"`. The fix here is to simply remove quotes from keys inside to_dict() when possible.

You may want to look into this a bit further, though, because the way the parser currently works, it will accept the same key in multiple places as long as they are quoted in different ways. As far as I can tell, this is an incorrect yaml document:
```
"a": b
'a': c
a: d
```
But yamlium will happily parse it as a map with three different keys:
```
yamlium.parse('"a": b\n\'a\': c\na: d')
Key('"a"'): Scalar('b')
Key(''a''): Scalar('c')
Key('a'): Scalar('d')
```
My fix does not address this. to_yaml() will render this back as an incorrect yaml document, but to_dict() will now generate the dictionary `{"a": "d"}` .