### PR TITLE
fix: normalize quoted keys at parse time

### DIFF
--- a/tests/test_parser_to_json.py
+++ b/tests/test_parser_to_json.py
@@ -357,3 +357,27 @@ flow: { "key": "value", '"key2"': value2 }
             }
         }
     )
+
+
+def test_quoted_key_lookup():
+    """Test that quoted keys can be looked up without quotes"""
+    from yamlium import parse
+
+    m = parse('"a": b')
+    assert m["a"] == "b"
+
+    m2 = parse("'key': value")
+    assert m2["key"] == "value"
+
+    m3 = parse('flow: { "x": 1, "y": 2 }')
+    assert m3["flow"]["x"] == 1
+    assert m3["flow"]["y"] == 2
+
+
+def test_quoted_key_deduplication():
+    """Test that differently quoted keys resolve to the same key"""
+    from yamlium import parse
+
+    m = parse('"a": b\na: d')
+    assert m.to_dict() == {"a": "d"}
+    assert m["a"] == "d"

--- a/yamlium/lexer.py
+++ b/yamlium/lexer.py
@@ -428,7 +428,10 @@ class Lexer:
         if self.c == ":":
             self._nc()
             return self._build_token(
-                t=T.KEY, value=self.input[start.position : self.position - 1], s=start
+                t=T.KEY,
+                value=self.input[start.position + 1 : self.position - 2],
+                s=start,
+                quote_char=quote_char,
             )
 
         return self._build_token(

--- a/yamlium/nodes.py
+++ b/yamlium/nodes.py
@@ -60,11 +60,6 @@ def _preserve_metadata(old_value: Node | None, new_value: Node) -> Node:
     return new_value
 
 
-def _strip_quotes(value):
-    if len(value) >= 2 and value[0] in ('"', "'") and value[0] == value[-1]:
-        return value[1:-1]
-    return value
-
 
 class StrManipulator:
     """This class allows string manipulation."""
@@ -318,8 +313,7 @@ class Node:
                     else:
                         val.update(v.to_dict())  # type: ignore
                 else:
-                    key = _strip_quotes(k._value)
-                    val[key] = v.to_dict()
+                    val[k._value] = v.to_dict()
             return val
         if isinstance(self, Alias):
             return self.child.to_dict()
@@ -435,6 +429,7 @@ class Key(Node):
         _line: int = -99,
         _indent: int = -99,
         _is_merge_key: bool = False,
+        _quote_char: str | None = None,
     ) -> None:
         """Initialize a Key node.
 
@@ -443,9 +438,11 @@ class Key(Node):
             _line: The line number in the source YAML file.
             _indent: The indentation level in the source YAML file.
             _is_merge_key: Whether this is a merge key (<<).
+            _quote_char: The quote character used in the source YAML file.
         """
         super().__init__(_value, _line, _indent)
         self._is_merge_key = _is_merge_key
+        self._quote_char = _quote_char
         self.anchor: str | None = None
 
     def __str__(self) -> str:
@@ -459,7 +456,8 @@ class Key(Node):
 
     def _to_yaml(self) -> str:
         anch = f" &{self.anchor}" if self.anchor else ""
-        return self._enrich_yaml(self._value + ":" + anch)  # type: ignore
+        val = f"{self._quote_char}{self._value}{self._quote_char}" if self._quote_char else self._value
+        return self._enrich_yaml(val + ":" + anch)  # type: ignore
 
 
 class Sequence(list, Node):

--- a/yamlium/parser.py
+++ b/yamlium/parser.py
@@ -165,6 +165,7 @@ class Parser:
                 _line=t.line,
                 _is_merge_key=t.value == "<<",
                 _indent=self.current_indent,
+                _quote_char=t.quote_char,
             )
         )
 


### PR DESCRIPTION
## Summary
- Quoted YAML keys (`"a"`, `'a'`) now store the clean value in `Key._value` with `_quote_char` as metadata, matching how `Scalar` already works
- Fixes `mapping["a"]` raising `KeyError` for quoted keys, `Key.__eq__`/`__hash__` treating `"a"` and `a` as different keys, and `to_dict()` returning quoted key strings
- Replaces the `_strip_quotes` workaround from #60 with a root-cause fix in the lexer

## Test plan
- [x] All 274 tests pass (including PR #60's `test_quoted_keys` and `test_flow_style`)
- [x] New `test_quoted_key_lookup` and `test_quoted_key_deduplication` tests added
- [x] mypy type checking passes