### PR TITLE
fix: support anchors on sequence items

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1122,3 +1122,66 @@ unit_tests:
           - { id: 2, report_date: "2025-01-02", is_latest: true }
 """,
     )
+
+
+def test_anchor_on_sequence_item_mapping():
+    """Test anchor placed on a sequence item that is a mapping."""
+    comp("""
+items:
+  - &my_anchor
+    key: value
+    other: data
+  - *my_anchor
+""")
+
+
+def test_anchor_on_sequence_item_scalar():
+    """Test anchor placed on a sequence item that is a scalar."""
+    comp("""
+items:
+  - &my_scalar hello
+  - *my_scalar
+""")
+
+
+def test_anchor_on_sequence_item_with_nested_alias():
+    """Test anchor on sequence item with alias used in nested context."""
+    comp("""
+items:
+  - &my_anchor
+    key: value
+    other: data
+
+  - *my_anchor
+
+  - name: something
+    nested:
+      - *my_anchor
+""")
+
+
+def test_anchor_on_sequence_item_mapping_values():
+    """Test that anchored sequence item mapping resolves correctly."""
+    input_yaml = """
+items:
+  - &my_anchor
+    key: value
+    other: data
+  - *my_anchor
+""".strip() + "\n"
+    result = parse(input_yaml)
+    assert result["items"][0].to_dict() == {"key": "value", "other": "data"}
+    assert result["items"][1].to_dict() == {"key": "value", "other": "data"}
+
+
+def test_multiple_anchors_on_sequence_items():
+    """Test multiple different anchors on sequence items."""
+    comp("""
+items:
+  - &first
+    a: 1
+  - &second
+    b: 2
+  - *first
+  - *second
+""")

--- a/yamlium/nodes.py
+++ b/yamlium/nodes.py
@@ -90,6 +90,7 @@ class Node:
         self._indent = _indent
         self._column: int = -99
         self.newlines: int = 0
+        self.anchor: str | None = None
         self.comments: Comments = Comments()
 
     # Backward compatibility properties (deprecated)
@@ -443,7 +444,6 @@ class Key(Node):
         super().__init__(_value, _line, _indent)
         self._is_merge_key = _is_merge_key
         self._quote_char = _quote_char
-        self.anchor: str | None = None
 
     def __str__(self) -> str:
         return str(self._value)
@@ -490,17 +490,23 @@ class Sequence(list, Node):
             # Check if we should print standalone comments
             items.extend(x._get_head_comments(i=i))
 
+            anchor_str = f"&{x.anchor} " if x.anchor else ""
+
             # If child is a mapping
             if isinstance(x, Mapping):
                 if x._is_inline:
                     prefix = _indent(i) + "- "
-                    items.append(f"{prefix}{x._to_yaml()}")
+                    items.append(f"{prefix}{anchor_str}{x._to_yaml()}")
                     if x.newlines > 0:
                         items[-1] += "\n" * x.newlines
                     continue
                 is_first_item = True
                 for k, v in x.items():
-                    if is_first_item:
+                    if is_first_item and x.anchor:
+                        items.append(f"{_indent(i)}- &{x.anchor}")
+                        prefix = _indent(i) + "  "
+                        items.extend(k._get_head_comments(i=i + 1))
+                    elif is_first_item:
                         prefix = _indent(i) + "- "
                         items.extend(k._get_head_comments(i=i))
                     else:
@@ -525,9 +531,9 @@ class Sequence(list, Node):
             else:
                 prefix = _indent(i) + "- "
                 if isinstance(x, Scalar):
-                    items.append(f"{prefix}{x._to_yaml(i + 1, foot_indent=i)}")
+                    items.append(f"{prefix}{anchor_str}{x._to_yaml(i + 1, foot_indent=i)}")
                 else:
-                    items.append(f"{prefix}{x._to_yaml(i + 1)}")
+                    items.append(f"{prefix}{anchor_str}{x._to_yaml(i + 1)}")
         return "\n".join(items)
 
     def append(self, item: Any) -> None:

--- a/yamlium/parser.py
+++ b/yamlium/parser.py
@@ -223,18 +223,22 @@ class Parser:
             # No blank line yet: potential foot of previous node
             self.pending_foot_comments.append(token.value)
 
-    def _handle_anchor(self) -> Mapping | Scalar | Sequence | Alias:
+    def _handle_anchor(
+        self, in_mapping: bool = False
+    ) -> Mapping | Scalar | Sequence | Alias:
         n = self._last_node
         t = self._take_token
-        if not isinstance(n, Key):
-            self._raise_parsing_error("Anchors can only be placed with keys.")
-        n.anchor = t.value
+        attach_to_key = in_mapping and isinstance(n, Key)
+
+        if attach_to_key:
+            n.anchor = t.value
 
         # Track that we're resolving this anchor (for circular reference detection)
         self.resolving_aliases.add(t.value)
         try:
-            # Now find the value beyond the anchor
             value = self._parse_value()
+            if not attach_to_key:
+                value.anchor = t.value
             self.anchors[t.value] = value
             return value
         finally:
@@ -299,7 +303,7 @@ class Parser:
         if t == T.DASH:
             return self._parse_sequence()
         if t == T.ANCHOR:
-            return self._handle_anchor()
+            return self._handle_anchor(in_mapping=in_mapping)
         if t == T.ALIAS:
             return self._build_alias()
         if t == T.MAPPING_START:


### PR DESCRIPTION
## Summary
- Anchors on sequence items (`- &anchor`) were either misattached to the parent key or raised `"Anchors can only be placed with keys"`
- Now correctly attaches anchors to the sequence item value and renders them in round-trip output

## Test plan
- [x] Added 5 new tests covering mapping anchors, scalar anchors, nested aliases, value resolution, and multiple anchors
- [x] Full test suite passes (279 tests)