### PR TITLE
feat: add read_markdown() for YAML frontmatter extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,33 @@ Comment types:
 - `comments.line` - inline comment on the same line
 - `comments.foot` - comments below a node (before a blank line)
 
+### Reading Markdown Frontmatter
+
+```python
+from yamlium import read_markdown
+
+# Parse a markdown file with YAML frontmatter
+frontmatter, content = read_markdown("post.md")
+
+if frontmatter:
+    print(frontmatter["title"])  # Access YAML fields
+    print(content)               # Raw markdown after the frontmatter
+
+# Also works with raw strings
+text = """---
+title: My Post
+tags: [python, yaml]
+---
+# Hello World
+
+This is the body.
+"""
+frontmatter, content = read_markdown(text)
+```
+
+Supports both standard (`---`-delimited) and open (bare YAML followed by `---`) frontmatter formats.
+If no frontmatter is detected, returns `(None, full_text)`.
+
 ### JSON Conversion
 
 ```python
@@ -144,6 +171,7 @@ yaml_data = from_dict(python_dict)
 
 - `parse(input: str | Path) -> Mapping` Parse a single YAML document
 - `parse_full(input: str | Path) -> Document` Parse multiple YAML documents
+- `read_markdown(input: str | Path) -> tuple[Mapping | None, str]` Extract YAML frontmatter and content from markdown
 - `from_json(input: str | Path) -> Mapping | Sequence` Convert JSON to YAML structure
 - `from_dict(input: dict | list) -> Mapping | Sequence` Convert Python dict/list to YAML structure
 

--- a/tests/test_root_functions.py
+++ b/tests/test_root_functions.py
@@ -11,6 +11,7 @@ from yamlium import (
     from_json,
     parse,
     parse_full,
+    read_markdown,
 )
 
 
@@ -217,3 +218,122 @@ def test_file_not_found():
 
     with pytest.raises(FileNotFoundError):
         from_json("nonexistent.json")
+
+
+# --- read_markdown tests ---
+
+
+def test_read_markdown_standard_frontmatter():
+    text = "---\ntitle: Hello\ntags: [a, b]\n---\n# My Post\n\nBody here.\n"
+    fm, content = read_markdown(text)
+    assert isinstance(fm, Mapping)
+    assert fm["title"] == "Hello"
+    assert fm["tags"][0] == "a"
+    assert content == "# My Post\n\nBody here.\n"
+
+
+def test_read_markdown_open_format():
+    text = "key: value1\nkey2:\n  - item1\n  - item2\n---\nThis is raw content.\n"
+    fm, content = read_markdown(text)
+    assert isinstance(fm, Mapping)
+    assert fm["key"] == "value1"
+    assert fm["key2"][0] == "item1"
+    assert content == "This is raw content.\n"
+
+
+def test_read_markdown_no_frontmatter():
+    text = "# Just a heading\n\nSome paragraph text.\n"
+    fm, content = read_markdown(text)
+    assert fm is None
+    assert content == text
+
+
+def test_read_markdown_empty_frontmatter():
+    text = "---\n---\nContent after empty frontmatter.\n"
+    fm, content = read_markdown(text)
+    assert isinstance(fm, Mapping)
+    assert len(fm) == 0
+    assert content == "Content after empty frontmatter.\n"
+
+
+def test_read_markdown_frontmatter_with_comments():
+    text = "---\n# a yaml comment\ntitle: Hello\n---\nBody.\n"
+    fm, content = read_markdown(text)
+    assert fm["title"] == "Hello"
+    assert content == "Body.\n"
+
+
+def test_read_markdown_content_with_triple_dashes():
+    """Only the first closing --- is used as the frontmatter delimiter."""
+    text = "---\ntitle: Hello\n---\nFirst section\n---\nSecond section\n"
+    fm, content = read_markdown(text)
+    assert fm["title"] == "Hello"
+    assert content == "First section\n---\nSecond section\n"
+
+
+def test_read_markdown_open_format_content_with_triple_dashes():
+    text = "key: val\n---\nPart one\n---\nPart two\n"
+    fm, content = read_markdown(text)
+    assert fm["key"] == "val"
+    assert content == "Part one\n---\nPart two\n"
+
+
+def test_read_markdown_only_opening_separator():
+    """A single --- with no content before it and no closing --- means no frontmatter."""
+    text = "---\nThis looks like yaml but has no closing separator\n"
+    fm, content = read_markdown(text)
+    assert fm is None
+    assert content == text
+
+
+def test_read_markdown_file_path(tmp_path: Path):
+    md_file = tmp_path / "post.md"
+    md_file.write_text("---\ntitle: From File\n---\n# Heading\n")
+    fm, content = read_markdown(md_file)
+    assert fm["title"] == "From File"
+    assert content == "# Heading\n"
+
+
+def test_read_markdown_string_path(tmp_path: Path):
+    md_file = tmp_path / "post.md"
+    md_file.write_text("---\ntitle: From String Path\n---\nBody.\n")
+    fm, content = read_markdown(str(md_file))
+    assert fm["title"] == "From String Path"
+    assert content == "Body.\n"
+
+
+def test_read_markdown_path_object_non_md(tmp_path: Path):
+    """Path objects are always read regardless of extension."""
+    txt_file = tmp_path / "data.txt"
+    txt_file.write_text("---\nkey: val\n---\nstuff\n")
+    fm, content = read_markdown(txt_file)
+    assert fm["key"] == "val"
+    assert content == "stuff\n"
+
+
+def test_read_markdown_preserves_yaml_structure():
+    text = "---\n# Comment above\nname: test # inline\n---\nBody.\n"
+    fm, content = read_markdown(text)
+    yaml_out = fm.to_yaml()
+    assert "# Comment above" in yaml_out
+    assert "# inline" in yaml_out
+
+
+def test_read_markdown_leading_newline():
+    text = "\n---\ntitle: Hello\n---\nBody.\n"
+    fm, content = read_markdown(text)
+    assert fm["title"] == "Hello"
+    assert content == "Body.\n"
+
+
+def test_read_markdown_no_trailing_content():
+    text = "---\ntitle: Hello\n---\n"
+    fm, content = read_markdown(text)
+    assert fm["title"] == "Hello"
+    assert content == ""
+
+
+def test_read_markdown_empty_string():
+    fm, content = read_markdown("")
+    assert fm is None
+    assert content == ""

--- a/yamlium/__init__.py
+++ b/yamlium/__init__.py
@@ -1,10 +1,13 @@
 __version__ = "0.2.4"
 import json
+import re
 from pathlib import Path
 
 from .exceptions import ParsingError
 from .nodes import Alias, Document, Mapping, Scalar, Sequence, _convert_type
 from .parser import Parser
+
+_FRONTMATTER_SEP = re.compile(r"^---[ \t]*$", re.MULTILINE)
 
 
 def parse_full(input: str | Path) -> Document:
@@ -82,6 +85,66 @@ def from_json(input: str | Path) -> Mapping | Sequence:
     return result  # type: ignore
 
 
+def read_markdown(input: str | Path) -> tuple[Mapping | None, str]:
+    """Parse a markdown file or string, extracting YAML frontmatter if present.
+
+    Supports two frontmatter formats:
+    - Standard: file starts with ``---``, YAML content, then closing ``---``
+    - Open: YAML content followed by ``---`` (no opening delimiter)
+
+    If no frontmatter is detected, returns ``(None, full_text)``.
+
+    Args:
+        input: Either a Path object, a string path ending in .md/.markdown,
+            or a raw string containing markdown content.
+
+    Returns:
+        A tuple of (frontmatter, content) where frontmatter is a Mapping
+        or None, and content is the raw string after the frontmatter.
+    """
+    if isinstance(input, Path):
+        text = input.read_text()
+    elif input.endswith((".md", ".markdown")):
+        text = Path(input).read_text()
+    else:
+        text = input
+
+    separators = list(_FRONTMATTER_SEP.finditer(text))
+
+    if not separators:
+        return None, text
+
+    first = separators[0]
+
+    # Standard frontmatter: --- is the first non-whitespace content
+    if not text[: first.start()].strip():
+        if len(separators) < 2:
+            return None, text
+        second = separators[1]
+        yaml_start = first.end() + 1 if first.end() < len(text) else first.end()
+        yaml_str = text[yaml_start : second.start()]
+        content_start = second.end()
+        if content_start < len(text) and text[content_start] == "\n":
+            content_start += 1
+        content = text[content_start:]
+
+        if not yaml_str.strip():
+            return Mapping({}), content
+        return parse(yaml_str), content
+
+    # Open format: YAML before the first ---
+    yaml_str = text[: first.start()]
+    if not yaml_str.strip():
+        return None, text
+
+    content_start = first.end()
+    if content_start < len(text) and text[content_start] == "\n":
+        content_start += 1
+    content = text[content_start:]
+
+    return parse(yaml_str), content
+
+
 def from_dict(input: dict | list) -> Mapping | Sequence:
     """Convert a Python dictionary or list into a Mapping or Sequence object.
 
@@ -102,7 +165,10 @@ def from_dict(input: dict | list) -> Mapping | Sequence:
 
 __all__ = [
     "parse",
+    "parse_full",
+    "read_markdown",
     "from_dict",
+    "from_json",
     "Mapping",
     "Sequence",
     "Scalar",


### PR DESCRIPTION
## Summary
- Add `read_markdown(input) -> tuple[Mapping | None, str]` for extracting YAML frontmatter from markdown files
- Supports standard format (`---`-delimited) and open format (bare YAML followed by `---`)
- Returns `(None, full_text)` when no frontmatter is detected
- Accepts Path objects, `.md`/`.markdown` string paths, or raw strings

Closes #65